### PR TITLE
Add endpoint to like a comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.gitpod.yml
+sampleEVENTAPP.db

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify
+from events.routes import comment_likes_bp  # Importing the Blueprint from where I've defined it
 # I imported jsonify so that the output of the status will be of better formatting
 from group.routes import group_bp
 from events.routes import event_bp
@@ -8,6 +9,9 @@ from auth.routes import auth
 import models
 
 app = Flask(__name__)
+
+# Register the Blueprint with the Flask app
+app.register_blueprint(comment_likes_bp)
 
 # app.config.from_object(Config)
 # db.init_app(app)

--- a/events/routes.py
+++ b/events/routes.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, abort, jsonify
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
 import models # storage will be used for all db session based queries
 from models.user import User
 from models.comment import Comment
@@ -31,3 +32,37 @@ def retrieve_comments_by_event(event_id):
     except Exception as e:
         models.storage.session.rollback()
         return jsonify({"error": e}), 404
+
+comment_likes_bp = Blueprint('comment_likes', __name__)
+
+"""
+    A POST Endpoint that adds a like to a comment
+"""
+@comment_likes_bp.route('/api/<int:comment_id>/<string:user_id>/likes', methods=['POST'])
+@jwt_required
+def add_like_to_comment(comment_id, user_id):
+    comment = Comment.query.get(comment_id)
+
+    # Check if the comment exists
+    if not comment:
+        return jsonify({"error": "Comment not found"}), 404
+
+    # Check if the user has already liked the comment
+    if user_id in comment.likes:
+        return jsonify({"error": "User has already liked this comment"}), 400
+
+    try:
+        # Append the user_id to the comment's likes and save
+        comment.likes.append(user_id)
+        models.storage.save()
+
+        return jsonify(
+            {
+                'success': True,
+                'comment_id': comment.id,
+                'likes': comment.likes
+            }
+        )
+    except Exception as e:
+        models.storage.session.rollback()
+        return jsonify({"error": str(e)}), 500

--- a/models/comment.py
+++ b/models/comment.py
@@ -1,5 +1,5 @@
 """Model for Comment table"""
-from sqlalchemy import Column, String, ForeignKey
+from sqlalchemy import Column, String, ForeignKey, ARRAY
 from models.basemodel import BaseModel, Base
 
 
@@ -10,6 +10,8 @@ class Comment(BaseModel, Base):
     body = Column(String(1024))
     user_id = Column(String(60), ForeignKey("users.id"))
     event_id = Column(String(60), ForeignKey("events.id"))
+     # This field will store the user IDs of those who liked the comment.
+    likes = Column(ARRAY(String), default=[])
 
     def __init__(self, body: str, user_id: str, event_id: str):
         """Initialized the comment"""


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue #67 

**Like Comment Endpoint Documentation**

**Overview:**
This pull request introduces a new endpoint that allows users to 'like' a comment. This like operation is idempotent, meaning if a user tries to like a comment they've already liked, they'll get an error message.

**Endpoint:**

**`POST /api/<int:comment_id>/<string:user_id>/likes`**

**Parameters:**

* 'comment_id': The ID of the comment the user wants to like.
* 'user_id': The ID of the user liking the comment.

**Headers:**

* 'Authorization': JWT token to ensure the user is authenticated.

Response:

**Success:**

* Status Code: **`200 OK`**
* Body:

```json
{
    "success": True,
    "comment_id": <comment_id>,
    "likes": [<array of user_ids who have liked the comment>]
}
```

**User Has Already Liked:**

* Status Code: **`400 Bad Request`**
* Body:

```json
{
    "error": "User has already liked this comment"
}
```

**Comment Not Found:**

* Status Code: **`404 Not Found`
* Body:

```json
{
    "error": "Comment not found"
}
```

**Server Error**:

* Status Code: **`500 Internal Server Error`**
* Body: 
```json
{
    "error": <error description>
}
```

**Example Usage:**

To like a comment with ID `93586bjxnj568yb2e989` as a user with ID `6504be151ab2e9ff5c476248`:
```bash
curl -X POST \
     -H "Authorization: Bearer <YOUR_JWT_TOKEN>" \
     http://your-api-url/api/93586bjxnj568yb2e989/6504be151ab2e9ff5c476248/likes
```