### PR TITLE
Add endpoint to like comment

### DIFF
--- a/views/comment.py
+++ b/views/comment.py
@@ -97,7 +97,7 @@ def unlike_comment(comment_id, user_id):
 
 @api_views.route("/<comment_id>/<user_id>/likes", methods=["POST"]) 
 def add_like_to_comment(comment_id, user_id):
-    comment = Comment.query.get(comment_id)
+    models.storage.get("Comment", comment_id)
 
     # Check if the comment exists
     if not comment:
@@ -110,7 +110,7 @@ def add_like_to_comment(comment_id, user_id):
     try:
         # Append the user_id to the comment's likes and save
         comment.likes.append(user_id)
-        models.storage.save()
+        comment.save()
 
         return jsonify(
             {


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue #67 

**Like Comment Endpoint Documentation**

**Overview:**
This pull request introduces a new endpoint that allows users to 'like' a comment. This like operation is idempotent, meaning if a user tries to like a comment they've already liked, they'll get an error message.

**Endpoint:**

**`POST /<int:comment_id>/<string:user_id>/likes`**

**Parameters:**

* `comment_id`: The ID of the comment the user wants to like.
* `user_id`: The ID of the user liking the comment.

Response:

**Success:**

* Status Code: **`200 OK`**
* Body:

```json
{
    "success": True,
    "comment_id": <comment_id>,
    "likes": [<array of user_ids who have liked the comment>]
}
```

**User Has Already Liked:**

* Status Code: **`400 Bad Request`**
* Body:

```json
{
    "error": "User has already liked this comment"
}
```

**Comment Not Found:**

* Status Code: **`404 Not Found`
* Body:

```json
{
    "error": "Comment not found"
}
```

**Server Error**:

* Status Code: **`500 Internal Server Error`**
* Body: 
```json
{
    "error": <error description>
}
```

**Example Usage:**

To like a comment with ID `93586bjxnj568yb2e989` as a user with ID `6504be151ab2e9ff5c476248`:
```bash
curl -X POST \
     http://your-api-url/93586bjxnj568yb2e989/6504be151ab2e9ff5c476248/likes
```